### PR TITLE
fix: Add GKE auth plugin environment variable for CI/CD workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ env:
   GKE_CLUSTER: ${{ secrets.GKE_CLUSTER_NAME || 'multi-k8s-cluster' }}
   GKE_ZONE: ${{ secrets.GKE_ZONE || 'southamerica-east1-a' }}
   DEPLOYMENT_NAME: ${{ secrets.DEPLOYMENT_NAME || 'multi-k8s' }}
+  USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
 
 jobs:
   setup-build-publish-deploy:

--- a/.github/workflows/setup-infrastructure.yml
+++ b/.github/workflows/setup-infrastructure.yml
@@ -17,6 +17,7 @@ env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
   TF_VAR_postgres_password: ${{ secrets.POSTGRES_PASSWORD }}
+  USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
 
 jobs:
   terraform:


### PR DESCRIPTION
## Summary
- Add USE_GKE_GCLOUD_AUTH_PLUGIN environment variable to GitHub Actions workflows
- Fix kubectl authentication errors in CI/CD pipeline
- Resolve "gke-gcloud-auth-plugin not found" error

## Changes Made
- Added `USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'` to deploy.yml workflow
- Added `USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'` to setup-infrastructure.yml workflow
- This enables the new GKE authentication plugin required for kubectl operations

## Problem Solved
Previously, GitHub Actions workflows would fail with:
```
error: failed to create secret Post "https://...": getting credentials: exec: executable gke-gcloud-auth-plugin not found
```

This fix ensures kubectl can properly authenticate with GKE clusters in CI/CD environments.

## Test plan
- [x] Local kubectl authentication working with auth plugin enabled
- [x] GKE cluster accessible and operational
- [x] Secret creation and kubectl operations functioning
- [ ] GitHub Actions workflows should no longer fail with auth plugin errors (to be verified after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>