### PR TITLE
fix: Install gke-gcloud-auth-plugin explicitly in GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,10 @@ jobs:
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+    - name: Install GKE auth plugin
+      run: |
+        gcloud components install gke-gcloud-auth-plugin --quiet
+
     - name: Configure Docker to use gcloud as credential helper
       run: |
         gcloud auth configure-docker

--- a/.github/workflows/setup-infrastructure.yml
+++ b/.github/workflows/setup-infrastructure.yml
@@ -47,6 +47,10 @@ jobs:
       with:
         version: 'latest'
 
+    - name: Install GKE auth plugin
+      run: |
+        gcloud components install gke-gcloud-auth-plugin --quiet
+
     - name: Create Terraform Backend Bucket
       run: |
         BUCKET_NAME="${{ env.PROJECT_ID }}-terraform-state"


### PR DESCRIPTION
## Summary
- Add explicit installation step for gke-gcloud-auth-plugin in GitHub Actions workflows
- Resolves persistent "executable gke-gcloud-auth-plugin not found" error in CI/CD
- Ensures kubectl can authenticate with GKE clusters in GitHub Actions environment

## Problem
Even with `USE_GKE_GCLOUD_AUTH_PLUGIN=True` environment variable, GitHub Actions workflows were still failing with:
```
error: exec: executable gke-gcloud-auth-plugin not found
```

## Root Cause
The environment variable only enables the plugin, but the plugin itself needs to be explicitly installed in the GitHub Actions runner environment.

## Solution
Added explicit installation step in both workflows:

### deploy.yml
```yaml
- name: Install GKE auth plugin
  run: |
    gcloud components install gke-gcloud-auth-plugin --quiet
```

### setup-infrastructure.yml  
```yaml
- name: Install GKE auth plugin
  run: |
    gcloud components install gke-gcloud-auth-plugin --quiet
```

## Changes Made
- ✅ Added plugin installation step to `deploy.yml` workflow
- ✅ Added plugin installation step to `setup-infrastructure.yml` workflow
- ✅ Plugin installation happens after gcloud setup and authentication
- ✅ Uses `--quiet` flag to suppress interactive prompts

## Test Plan
- [x] Local kubectl operations working with plugin
- [x] Terraform infrastructure deployment successful
- [x] GKE cluster operational with NGINX ingress
- [ ] GitHub Actions workflows should complete successfully (to be verified after merge)

## Impact
This fix ensures that:
1. GitHub Actions can create Kubernetes secrets via kubectl
2. Application deployment workflows will not fail with authentication errors
3. CI/CD pipeline becomes fully functional for GKE deployments

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>