### PR TITLE
ci: gate Dependabot auto-merge on end-to-end container flow test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      client-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      server-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      worker-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge for Dependabot PRs that are patch or
+# minor updates. GitHub will only complete the merge once all required status
+# checks pass (i.e. the "integration-test" gate). Major updates are left for
+# manual review.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve the PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,34 @@
+name: Integration Test
+
+# Spins up the full stack in containers and exercises the end-to-end flow
+# (client -> api -> redis/worker -> postgres). This is the gate that must pass
+# before a Dependabot update can be auto-merged.
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+jobs:
+  integration-test:
+    name: integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and start the full stack
+        run: docker compose -f docker-compose.ci.yml up --build -d
+
+      - name: Run end-to-end smoke test
+        run: |
+          chmod +x scripts/smoke-test.sh
+          RETRIES=40 ./scripts/smoke-test.sh
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.ci.yml logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.ci.yml down -v

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,58 @@
+# docker-compose used ONLY by CI (.github/workflows/integration-test.yml)
+# Brings up the full stack (postgres + redis + api + worker + client) so the
+# end-to-end flow can be exercised before a Dependabot update is auto-merged.
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres_password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+
+  api:
+    build:
+      context: ./server
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      PGUSER: postgres
+      PGHOST: postgres
+      PGDATABASE: postgres
+      PGPASSWORD: postgres_password
+      PGPORT: 5432
+    ports:
+      - "5000:5000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: ./worker
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  client:
+    build:
+      context: ./client
+    ports:
+      - "3000:3000"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# End-to-end smoke test of the running stack.
+# Exercises client -> api -> redis/worker -> postgres so we know the app is
+# 100% functional before a Dependabot update is auto-merged.
+set -euo pipefail
+
+API="${API:-http://localhost:5000}"
+CLIENT="${CLIENT:-http://localhost:3000}"
+INDEX=5            # worker computes fib(INDEX) and stores it in Redis
+
+retry() {
+  local desc="$1"; shift
+  local tries="${RETRIES:-30}"
+  for i in $(seq 1 "$tries"); do
+    if "$@"; then return 0; fi
+    echo "  ...waiting for $desc ($i/$tries)"; sleep 3
+  done
+  echo "FAIL: $desc never became ready"; return 1
+}
+
+echo "==> 1. API is up (GET /)"
+retry "api root" bash -c "curl -fs $API/ | grep -q 'Hi'"
+
+echo "==> 2. Client is served (GET / on :3000)"
+retry "client" bash -c "curl -fs $CLIENT/ | grep -qi '<div id=\"root\">'"
+
+echo "==> 3. POST a value (index=$INDEX)"
+curl -fs -X POST "$API/values" \
+  -H 'Content-Type: application/json' \
+  -d "{\"index\":\"$INDEX\"}" | grep -q 'working'
+echo "    posted ok"
+
+echo "==> 4. Value is persisted in Postgres (GET /values/all)"
+retry "postgres row" bash -c "curl -fs $API/values/all | grep -q '\"number\":$INDEX'"
+
+# The worker subscribes to Redis and replaces the "Nothing yet!" placeholder
+# with the computed Fibonacci number. We assert it became numeric (worker ran),
+# rather than a specific value, so the test is independent of the fib indexing.
+echo "==> 5. Worker computed fib($INDEX) into Redis (GET /values/current)"
+retry "worker result" bash -c "curl -fs $API/values/current | grep -qE '\"$INDEX\":\"[0-9]+\"'"
+
+echo ""
+echo "SMOKE TEST PASSED: full flow client -> api -> redis/worker -> postgres is healthy."


### PR DESCRIPTION
## O que muda

Adiciona um **teste de fluxo end-to-end em containers** como gate antes do auto-merge de updates do Dependabot.

- `docker-compose.ci.yml`: sobe a stack completa (postgres + redis + api + worker + client)
- `scripts/smoke-test.sh`: valida o fluxo real (client → api → redis/worker → postgres)
- `integration-test.yml`: roda o teste de fluxo em cada PR/push
- `dependabot-automerge.yml`: auto-aprova e habilita auto-merge para updates **patch/minor** — só conclui quando o gate `integration-test` fica verde. Major fica para revisão manual.
- `dependabot.yml`: updates semanais agrupados (client/server/worker + github-actions)

Fluxo validado localmente: smoke test passou 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)