### PR TITLE
ci: fix legacy Run Tests (react-router-dom 7 under react-scripts jest)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,12 @@
   "jest": {
     "transformIgnorePatterns": [
       "node_modules/(?!(axios)/)"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js",
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router$": "<rootDir>/node_modules/react-router/dist/development/index.js"
+    }
   },
   "browserslist": {
     "production": [

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,11 @@
+// react-router v7 references TextEncoder/TextDecoder at import time, which the
+// CRA (jsdom) test environment does not provide by default. Polyfill them from
+// Node's util so the test suite can load react-router under react-scripts/jest.
+import { TextEncoder, TextDecoder } from 'util';
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
O workflow legado `Run Tests` quebrou após o bump do react-router-dom para 7: o jest do react-scripts 5 (jest 27, sem suporte ao campo `exports`) não resolvia o pacote (`Cannot find module 'react-router-dom'`).

**Correção (testada localmente — App.test.js passa):**
- `client/package.json`: `moduleNameMapper` apontando react-router-dom / react-router / react-router/dom para os builds CJS reais.
- `client/src/setupTests.js`: polyfill de `TextEncoder`/`TextDecoder` (o react-router 7 os usa no import; o jsdom não fornece).

O gate real (`integration-test`) já validava o app rodando; isto restaura também o workflow de unit test legado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)